### PR TITLE
Update 008-Bayesian-randomized-benchmarking.ipynb

### DIFF
--- a/008-Bayesian-randomized-benchmarking.ipynb
+++ b/008-Bayesian-randomized-benchmarking.ipynb
@@ -23,7 +23,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import time\n",
     "import copy\n",
     "from qiskit_experiments.library import StandardRB, InterleavedRB\n",
     "from qiskit_experiments.framework import ParallelExperiment\n",
@@ -1578,26 +1577,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "start experiments 02/09/2021 07:48:14\n",
-      "  end experiments 02/09/2021 07:53:33\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#prepare circuits\n",
     "int1exp = InterleavedRB(interleaved_circuit, qubits,\n",
     "                            lengths, num_samples=num_samples, seed=seed)\n",
     "#run\n",
-    "print(\"start experiments\",time.strftime('%d/%m/%Y %H:%M:%S'))\n",
-    "int1expdata = int1exp.run(backend).block_for_results()\n",
-    "print(\"  end experiments\",time.strftime('%d/%m/%Y %H:%M:%S'))"
+    "int1expdata = int1exp.run(backend).block_for_results()"
    ]
   },
   {


### PR DESCRIPTION
get rid of python time